### PR TITLE
Added SPM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 .build/
-
+.swiftpm
 # CocoaPods - Refactored to standalone file
 
 # Carthage - Refactored to standalone file

--- a/EmailValidator.xcodeproj/project.pbxproj
+++ b/EmailValidator.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 					};
 					20203BE21FCB833700117067 = {
 						CreatedOnToolsVersion = 9.1;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -340,10 +340,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 28HM56RH7C;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -363,10 +363,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 28HM56RH7C;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -385,13 +385,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = EmailValidatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.evanrobertson.EmailValidatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -401,13 +404,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = EmailValidatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.evanrobertson.EmailValidatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/EmailValidator/EmailValidator.swift
+++ b/EmailValidator/EmailValidator.swift
@@ -119,10 +119,10 @@ public class EmailValidator {
         while index < text.endIndex && isDomain(c: text[index], allowInternational: allowInternational, type: &type) {
             index = text.index(after: index)
         }
-
         let previousIndex = text.index(before: index)
-        let offsetIndex = text.index(index, offsetBy: -startIndex.encodedOffset)
-        return offsetIndex.encodedOffset < 64 && text[previousIndex] != "-"
+        
+        let offsetIndex = text.index(index, offsetBy: -startIndex.utf16Offset(in: text))
+        return offsetIndex.utf16Offset(in: text) < 64 && text[previousIndex] != "-"
     }
 
     private class func skipDomain(text: String, index: inout String.Index, allowTopLevelDomains: Bool, allowInternational: Bool) -> Bool {
@@ -198,7 +198,7 @@ public class EmailValidator {
                 index = text.index(after: index)
             }
 
-            if index == startIndex || text.index(index, offsetBy: -startIndex.encodedOffset).encodedOffset > 3 || value > 255 {
+            if index == startIndex || text.index(index, offsetBy: -startIndex.utf16Offset(in: text)).utf16Offset(in: text) > 3 || value > 255 {
                 return false
             }
 
@@ -244,7 +244,7 @@ public class EmailValidator {
                 return compact ? colons < 6 : colons == 6
             }
 
-            var count = index.encodedOffset - startIndex.encodedOffset
+            var count = index.utf16Offset(in: text) - startIndex.utf16Offset(in: text)
             if count > 4 {
                 return false
             }
@@ -259,7 +259,7 @@ public class EmailValidator {
                 index = text.index(after: index)
             }
 
-            count = index.encodedOffset - startIndex.encodedOffset
+            count = index.utf16Offset(in: text) - startIndex.utf16Offset(in: text)
             if count > 2 {
                 return false
             }
@@ -291,7 +291,7 @@ public class EmailValidator {
     public class func validate(email: String, allowTopLevelDomains: Bool = false, allowInternational: Bool = false) -> Bool {
         var index = email.startIndex
 
-        if email.isEmpty || email.endIndex.encodedOffset >= 255 {
+        if email.isEmpty || email.endIndex.utf16Offset(in: email) >= 255 {
             return false
         }
 
@@ -316,7 +316,7 @@ public class EmailValidator {
         }
 
         let nextIndex = email.index(after: index)
-        if nextIndex >= email.endIndex || index.encodedOffset > 64 || email[index] != "@" {
+        if nextIndex >= email.endIndex || index.utf16Offset(in: email) > 64 || email[index] != "@" {
             return false
         }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "EmailValidator",
+    products: [
+        .library(
+            name: "EmailValidator",
+            targets: ["EmailValidator"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "EmailValidator",
+            dependencies: [],
+            path: "EmailValidator"),
+        .testTarget(
+            name: "EmailValidatorTests",
+            dependencies: ["EmailValidator"],
+            path: "EmailValidatorTests"),
+    ]
+)


### PR DESCRIPTION
This PR currently adds SPM support but there are separate issues that are unrelated to directly supporting SPM. See below.
```bash
% swift test
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:124:67: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
        let offsetIndex = text.index(index, offsetBy: -startIndex.encodedOffset)
                                                                  ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:125:28: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
        return offsetIndex.encodedOffset < 64 && text[previousIndex] != "-"
                           ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:201:79: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            if index == startIndex || text.index(index, offsetBy: -startIndex.encodedOffset).encodedOffset > 3 || value > 255 {
                                                                              ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:201:94: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            if index == startIndex || text.index(index, offsetBy: -startIndex.encodedOffset).encodedOffset > 3 || value > 255 {
                                                                                             ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:247:31: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            var count = index.encodedOffset - startIndex.encodedOffset
                              ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:247:58: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            var count = index.encodedOffset - startIndex.encodedOffset
                                                         ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:262:27: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            count = index.encodedOffset - startIndex.encodedOffset
                          ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:262:54: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
            count = index.encodedOffset - startIndex.encodedOffset
                                                     ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:294:44: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
        if email.isEmpty || email.endIndex.encodedOffset >= 255 {
                                           ^
/Users/twodayslate/Development/EmailValidator/EmailValidator/EmailValidator.swift:319:49: warning: 'encodedOffset' is deprecated: encodedOffset has been deprecated as most common usage is incorrect. Use utf16Offset(in:) to achieve the same behavior.
        if nextIndex >= email.endIndex || index.encodedOffset > 64 || email[index] != "@" {
                                                ^
[5/5] Linking EmailValidatorPackageTests
Test Suite 'All tests' started at 2020-02-16 13:21:10.431
Test Suite 'EmailValidatorPackageTests.xctest' started at 2020-02-16 13:21:10.431
Test Suite 'EmailValidatorTests' started at 2020-02-16 13:21:10.431
Test Case '-[EmailValidatorTests.EmailValidatorTests testInvalidAddresses]' started.
Test Case '-[EmailValidatorTests.EmailValidatorTests testInvalidAddresses]' passed (0.110 seconds).
Test Case '-[EmailValidatorTests.EmailValidatorTests testValidAddresses]' started.
Test Case '-[EmailValidatorTests.EmailValidatorTests testValidAddresses]' passed (0.002 seconds).
Test Case '-[EmailValidatorTests.EmailValidatorTests testValidInternationalAddresses]' started.
Fatal error: String index is out of bounds
Exited with signal code 4
```

Closes #2 